### PR TITLE
Implement a function to add ERC-20 tokens

### DIFF
--- a/src/Wallet.sol
+++ b/src/Wallet.sol
@@ -44,19 +44,16 @@ contract Wallet {
 
     function createWorldId() external onlyOwner {}
 
-    function transfer(
-        address _recipient,
-        address _token,
-        uint256 _amount
-    ) external onlyVerified(msg.sender) onlySupportedToken(_token) {
+    function transfer(address _recipient, address _token, uint256 _amount)
+        external
+        onlyVerified(msg.sender)
+        onlySupportedToken(_token)
+    {
         require(_recipient != address(0), "Zero address detected");
         IERC20 token = IERC20(_token);
         require(token.balanceOf(msg.sender) >= _amount, "Insufficient balance");
         require(_amount > 0, "Transfer amount must be greater than zero");
-        require(
-            token.transferFrom(msg.sender, _recipient, _amount),
-            "Transfer failed"
-        );
+        require(token.transferFrom(msg.sender, _recipient, _amount), "Transfer failed");
 
         recordTransactionHistory(msg.sender, _amount, _token);
     }
@@ -75,9 +72,7 @@ contract Wallet {
     //             View Functions              //
     ////////////////////////////////////////////
 
-    function getTransactionHistory(
-        address _user
-    ) external view returns (Transaction[] memory) {
+    function getTransactionHistory(address _user) external view returns (Transaction[] memory) {
         return transactions[_user];
     }
 
@@ -85,15 +80,8 @@ contract Wallet {
     //             Private Function              //
     //////////////////////////////////////////////
 
-    function recordTransactionHistory(
-        address _user,
-        uint256 _amount,
-        address _token
-    ) private {
-        Transaction memory newTransaction = Transaction({
-            amount: _amount,
-            token: _token
-        });
+    function recordTransactionHistory(address _user, uint256 _amount, address _token) private {
+        Transaction memory newTransaction = Transaction({amount: _amount, token: _token});
 
         transactions[_user].push(newTransaction);
     }

--- a/test/Transfer.t.sol
+++ b/test/Transfer.t.sol
@@ -121,7 +121,7 @@ contract USDTTransferTest is Test {
 
         // Perform the transfer
         vm.prank(user1);
-        transferContract.transfer(user2, transferAmount);
+        transferContract.transfer(user2, address(mockUSDT), transferAmount);
 
         // Assert balances after transfer
         assertEq(mockUSDT.balanceOf(user1), user1BalanceBefore - transferAmount);
@@ -134,7 +134,7 @@ contract USDTTransferTest is Test {
 
         vm.prank(user1);
         vm.expectRevert("Insufficient balance");
-        transferContract.transfer(user2, transferAmount);
+        transferContract.transfer(user2, address(mockUSDT), transferAmount);
     }
 
     // Test transfer function - Unverified user
@@ -146,7 +146,7 @@ contract USDTTransferTest is Test {
 
         vm.prank(user1);
         vm.expectRevert("User not verified");
-        transferContract.transfer(user2, transferAmount);
+        transferContract.transfer(user2, address(mockUSDT), transferAmount);
     }
 
     // Test transfer function - Transfer to unverified recipient
@@ -157,7 +157,7 @@ contract USDTTransferTest is Test {
 
         vm.expectRevert("User not verified");
 
-        transferContract.transfer(user2, transferAmount);
+        transferContract.transfer(user2, address(mockUSDT), transferAmount);
     }
 
     // Test transfer function - Multiple consecutive transfers
@@ -171,7 +171,7 @@ contract USDTTransferTest is Test {
 
         // First transfer
         vm.prank(user1);
-        transferContract.transfer(user2, transferAmount1);
+        transferContract.transfer(user2, address(mockUSDT), transferAmount1);
 
         // Assert balances after first transfer
         assertEq(mockUSDT.balanceOf(user1), user1BalanceBefore - transferAmount1);
@@ -182,7 +182,7 @@ contract USDTTransferTest is Test {
         user2BalanceBefore = mockUSDT.balanceOf(user2);
 
         vm.prank(user1);
-        transferContract.transfer(user2, transferAmount2);
+        transferContract.transfer(user2, address(mockUSDT), transferAmount2);
 
         assertEq(mockUSDT.balanceOf(user1), user1BalanceBefore - transferAmount2);
         assertEq(mockUSDT.balanceOf(user2), user2BalanceBefore + transferAmount2);
@@ -195,6 +195,6 @@ contract USDTTransferTest is Test {
         vm.prank(user1);
 
         vm.expectRevert("Transfer amount must be greater than zero");
-        transferContract.transfer(user2, transferAmount);
+        transferContract.transfer(user2, address(mockUSDT), transferAmount);
     }
 }

--- a/test/Wallet.t.sol
+++ b/test/Wallet.t.sol
@@ -48,7 +48,7 @@ contract WalletTest is Test {
     /// @notice Test recording a single transaction
     function testRecordSingleTransaction() public {
         vm.prank(user1);
-        wallet.transfer(user2, 100);
+        wallet.transfer(user2, address(usdt), 100);
 
         vm.prank(user1);
         Wallet.Transaction[] memory history = wallet.getTransactionHistory(user1);
@@ -60,8 +60,8 @@ contract WalletTest is Test {
     /// @notice Test recording multiple transactions
     function testRecordMultipleTransactions() public {
         vm.startPrank(user1);
-        wallet.transfer(user2, 100);
-        wallet.transfer(user2, 200);
+        wallet.transfer(user2, address(usdt), 100);
+        wallet.transfer(user2, address(usdt), 200);
 
         Wallet.Transaction[] memory history = wallet.getTransactionHistory(user1);
         vm.stopPrank();
@@ -76,13 +76,13 @@ contract WalletTest is Test {
     /// @notice Test recording transactions for different users
     function testRecordTransactionsForDifferentUsers() public {
         vm.prank(user1);
-        wallet.transfer(user2, 100);
+        wallet.transfer(user2, address(usdt), 100);
 
         vm.prank(user1);
-        wallet.transfer(user2, 50);
+        wallet.transfer(user2, address(usdt), 50);
 
         vm.prank(user2);
-        wallet.transfer(user1, 50);
+        wallet.transfer(user1, address(usdt), 50);
 
         vm.prank(user1);
         Wallet.Transaction[] memory user1History = wallet.getTransactionHistory(user1);
@@ -103,7 +103,7 @@ contract WalletTest is Test {
 
         vm.startPrank(user1);
         usdt.approve(address(wallet), largeAmount);
-        wallet.transfer(user2, largeAmount);
+        wallet.transfer(user2, address(usdt), largeAmount);
 
         Wallet.Transaction[] memory history = wallet.getTransactionHistory(user1);
         vm.stopPrank();


### PR DESCRIPTION
Closes #11 

This PR adds new features to allow the Wallet contract to manage which ERC-20 tokens it supports.

- [x] Add Tokens:
- [x] Remove Tokens:
- [x] Check Tokens:
- [x] Updates to Transfers: the transfer function now checks if a token is supported before allowing a transfer.

